### PR TITLE
Dockerfile update and fixed typo in tutorial

### DIFF
--- a/static-site/Dockerfile
+++ b/static-site/Dockerfile
@@ -5,5 +5,5 @@ RUN mkdir -p /usr/share/nginx/html
 COPY Hello_docker.html /usr/share/nginx/html
 
 WORKDIR /usr/share/nginx/html
-CMD cd /usr/share/nginx/html && sed -e s/Docker/$AUTHOR/ Hello_docker.html > index.html ; nginx -g 'daemon off;'
+CMD cd /usr/share/nginx/html && sed -e s/Docker/"$AUTHOR"/ Hello_docker.html > index.html ; nginx -g 'daemon off;'
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -195,7 +195,7 @@ $ docker-machine ip default
 You can now open [http://192.168.99.100:32772](http://192.168.99.100:32772) to see your site live! You can also specify a custom port to which the client will forward connections to the container.
 
 ```
-$ docker run --name static-site -e -e=Your_Name -d -p 8888:80 seqvence/static-site
+$ docker run --name static-site -e AUTHOR=Your_Name -d -p 8888:80 seqvence/static-site
 ```
 <img src="https://raw.githubusercontent.com/docker/Docker-Birthday-3/master/tutorial-images/static.png" title="static">
 


### PR DESCRIPTION
I use Docker v1.10.2 on OSX. I noticed that when the AUTHOR environment variable passed to the docker run command had spaces in it example "JOHN DOE", then the generated index.html was blank. This fixes that by enclosing $AUTHOR in quotes. Also have fixed a small typo in the tutorial.

