### PR TITLE
allow spaces in AUTHOR env variable

### DIFF
--- a/static-site/Dockerfile
+++ b/static-site/Dockerfile
@@ -5,5 +5,5 @@ RUN mkdir -p /usr/share/nginx/html
 COPY Hello_docker.html /usr/share/nginx/html
 
 WORKDIR /usr/share/nginx/html
-CMD cd /usr/share/nginx/html && sed -e s/Docker/$AUTHOR/ Hello_docker.html > index.html ; nginx -g 'daemon off;'
+CMD cd /usr/share/nginx/html && sed -e s/Docker/"$AUTHOR"/ Hello_docker.html > index.html ; nginx -g 'daemon off;'
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -491,7 +491,7 @@ If you don't have the `alpine:latest` image, the client will first pull the imag
 The last step in this section is to run the image and see if it actually works.
 
 ```
-$ docker run -p --name myfirstapp 8888:5000 YOUR_USERNAME/myfirstapp
+$ docker run -p 8888:5000 --name myfirstapp YOUR_USERNAME/myfirstapp
  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 ```
 


### PR DESCRIPTION
I use Docker v1.10.2 on OSX. I noticed that when the AUTHOR env variable in the docker run command had spaces in it, then the generated index.html is blank. This fixes that by enclosing $AUTHOR in quotes. Also fixed a typo in docker run command for running myfirstapp.