### PR TITLE
Set npm registry to http for restricted networks

### DIFF
--- a/example-voting-app/result-app/Dockerfile
+++ b/example-voting-app/result-app/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir /app
 WORKDIR /app
 
 ADD package.json /app/package.json
+RUN npm config set registry http://registry.npmjs.org
 RUN npm install && npm ls
 RUN mv /app/node_modules /node_modules
 


### PR DESCRIPTION
To prepare our PC pool at the University of Bamberg for the **Docker Birthday 3 event** we struggled building the `result-app`.

The University network is more restricted and so at the moment the `npm install` does not work. Good luck that we've tested the tutorial today. Before discussing with the sysadmins there (weekend) we found a solution by switching the NPM Registry from https to http.

This could also help others in company networks etc. And for this educational tutorial I think this is fine to get it running more easily.

![pc-pool-uni-bamberg](https://cloud.githubusercontent.com/assets/207759/13899165/e9760e44-ede6-11e5-83bf-6c3931c1a883.jpg)
Marcel, Mathias, Govinda and Andreas testing the Docker Toolbox setup on Windows 7 PC's
