### PR TITLE
Remove unnecessary links and volumes

### DIFF
--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -3,33 +3,22 @@ version: "2"
 services:
   voting-app:
     build: ./voting-app/.
-    volumes:
-     - ./voting-app:/app
     ports:
       - "5000:80"
-    links:
-      - redis
     networks:
       - front-tier
       - back-tier
 
   result-app:
     build: ./result-app/.
-    volumes:
-      - ./result-app:/app
     ports:
       - "5001:80"
-    links:
-      - db
     networks:
       - front-tier
       - back-tier
 
   worker:
     image: manomarks/worker
-    links:
-      - db
-      - redis
     networks:
       - back-tier
 


### PR DESCRIPTION
This app uses overlay networks so it can take advantage of simply
referring to services by container name rather than using
legacy links [1]. Note how links are unnecessary in this example [2].

This app builds images and the Dockerfile for those images uses the ADD
instruction to copy the code from the current folder to /app inside the
container so there's no need to do a volume mount.

[1] https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#legacy-container-links
[2] https://docs.docker.com/compose/networking/#specifying-custom-networks