### PR TITLE
Removed front-tier networks from voting-app and result-app

### DIFF
--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     links:
       - redis
     networks:
-      - front-tier
       - back-tier
 
   result-app:
@@ -22,7 +21,6 @@ services:
     links:
       - db
     networks:
-      - front-tier
       - back-tier
 
   worker:
@@ -50,5 +48,4 @@ volumes:
   db-data:
 
 networks:
-  front-tier:
   back-tier:


### PR DESCRIPTION
Removing the front-tier network from the voting-app and result-app now allows access from other interfaces and IPs rather than just localhost.  Tested the docker-birthday-3 training on an Ubuntu instance in EC2 and couldn't get to the demo sites from the local IP address or Public Elastic IP.  But I could curl from localhost on the instance.  Removed the front-tier networks in the docker-compose.yml file and all was well.  Not sure if this is a bug or if a better work around is out there.