### PR TITLE
make config.json better match tutorial

### DIFF
--- a/example-voting-app/result-app/views/config.json
+++ b/example-voting-app/result-app/views/config.json
@@ -2,6 +2,6 @@
   "name":"Gordon",
   "twitter":"@docker",
   "location":"San Francisco, CA, USA",
-  "repo":["example/examplevotingapp_voting-app","example/examplevotingapp_result-app"],
+  "repo":["example/votingapp_voting-app","example/votingapp_result-app"],
   "vote":"Cat"
 }


### PR DESCRIPTION
This tripped me up in my walkthrough: the instructions at https://github.com/docker/docker-birthday-3/blame/dd715359e6c86d0fc51c1c840e82dd3dc4c75086/tutorial.md#L764-L766 do not have the extra _example_ text after the forward slashes. This resulted in a failed submission for me the first time, because I did not notice this and submitted with the original config.json still having that extraneous text in place. Removing this from the config.json example makes it so that participants can simply edit their username before the forward slash, and follow tutorial.md as-is.