### PR TITLE
replaced links with container_name to leverage docker networking

### DIFF
--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -7,8 +7,6 @@ services:
      - ./voting-app:/app
     ports:
       - "5000:80"
-    links:
-      - redis
     networks:
       - front-tier
       - back-tier
@@ -19,28 +17,25 @@ services:
       - ./result-app:/app
     ports:
       - "5001:80"
-    links:
-      - db
     networks:
       - front-tier
       - back-tier
 
   worker:
     image: manomarks/worker
-    links:
-      - db
-      - redis
     networks:
       - back-tier
 
   redis:
     image: redis:alpine
+    container_name: redis
     ports: ["6379"]
     networks:
       - back-tier
 
   db:
     image: postgres:9.4
+    container_name: db
     volumes:
       - "db-data:/var/lib/postgresql/data"
     networks:


### PR DESCRIPTION
links are not useful if you are using docker networking, and won't work in a swarm cluster.
If you specify container_name for db and redis, the compose file will work with overlay networks in a Swarm cluster (by adding driver: overlay to configure the networks as overlay networks)