### PR TITLE
tutorial.md update - add note regarding how to resolve login issue

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -589,6 +589,8 @@ $ docker login
 
 And follow the login directions. Now you can push images to Docker Hub.
 
+> Note: If you encounter an error response from daemon while attempting to login, you may need to restart your machine by running `docker-machine restart <YOUR_DOCKER_MACHINE_NAME>`.
+
 
 <a id="pullimage"></a>
 ### 3.1 Get the voting-app


### PR DESCRIPTION
Hello! I participated in your birthday tutorial today (it was great, thank you!) and I encountered an issue when I ran `docker login` (`Error response from daemon: Server Error: Post https://index.docker.io/v1/users/: dial tcp: lookup index.docker.io on ...`). 

After some googling I discovered I could resolve it by restarting my machine. The people immediately around me had the same problem, so I figured I'd go ahead and submit a doc update for your consideration.

Thanks again for the tutorial and event!