### PR TITLE
merge interlock plugin to handle scale up/down voting-app

### DIFF
--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -39,9 +39,7 @@ services:
       - interlock-tier
 
   voting-app:
-    build: ./voting-app/.
-    volumes:
-     - ./voting-app:/app
+    image: titanlien/voting
     ports: 
      - "5000"
     networks:
@@ -52,9 +50,7 @@ services:
         - "interlock.domain=local"
 
   result-app:
-    build: ./result-app/.
-    volumes:
-      - ./result-app:/app
+    image: titanlien/result
     ports: 
       - "5001"
     networks:

--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -1,22 +1,62 @@
 version: "2"
 
 services:
+  interlock:
+    image: ehazlett/interlock:1.1.0
+    command: -D run
+    tty: true
+    ports: ["5000"]
+    environment:
+        INTERLOCK_CONFIG: |
+            ListenAddr = ":5000"
+            DockerURL = "unix:///var/run/docker.sock"
+            TLSCACert = "/var/lib/boot2docker/ca.pem"
+            TLSCert = "/var/lib/boot2docker/cert.pem"
+            TLSKey = "/var/lib/boot2docker/key.pem"
+            
+            [[Extensions]]
+            Name = "nginx"
+            ConfigPath = "/etc/nginx/nginx.conf"
+            PidPath = "/etc/nginx/nginx.pid"
+            BackendOverrideAddress = "172.17.0.1"
+            MaxConn = 1024
+            Port = 80
+    volumes:
+        - /Users/titan/.docker/machine/certs:/var/lib/boot2docker:ro
+        - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - interlock-tier
+
+  nginx:
+    image: nginx:latest
+    entrypoint: nginx
+    command: -g "daemon off;" -c /etc/nginx/nginx.conf
+    ports:
+        - 80:80
+    labels:
+        - "interlock.ext.name=nginx"
+    networks:
+      - interlock-tier
+
   voting-app:
     build: ./voting-app/.
     volumes:
      - ./voting-app:/app
-    ports:
-      - "5000:80"
+    ports: 
+     - "5000"
     networks:
       - front-tier
       - back-tier
+    labels:
+        - "interlock.hostname=test"
+        - "interlock.domain=local"
 
   result-app:
     build: ./result-app/.
     volumes:
       - ./result-app:/app
-    ports:
-      - "5001:80"
+    ports: 
+      - "5001"
     networks:
       - front-tier
       - back-tier
@@ -47,3 +87,4 @@ volumes:
 networks:
   front-tier:
   back-tier:
+  interlock-tier:

--- a/example-voting-app/result-app/Dockerfile
+++ b/example-voting-app/result-app/Dockerfile
@@ -9,7 +9,7 @@ RUN mv /app/node_modules /node_modules
 
 ADD . /app
 
-ENV PORT 80
-EXPOSE 80
+ENV PORT 5001
+EXPOSE 5001
 
 CMD ["node", "server.js"]

--- a/example-voting-app/result-app/views/config.json
+++ b/example-voting-app/result-app/views/config.json
@@ -1,7 +1,7 @@
 {
-  "name":"Gordon",
-  "twitter":"@docker",
-  "location":"San Francisco, CA, USA",
+  "name":"Titan Lien",
+  "twitter":"@titanlien",
+  "location":"Taipei, TW, Taiwan",
   "repo":["example/votingapp_voting-app","example/votingapp_result-app"],
-  "vote":"Cat"
+  "vote":"Left"
 }

--- a/example-voting-app/result-app/views/index.html
+++ b/example-voting-app/result-app/views/index.html
@@ -2,7 +2,7 @@
 <html ng-app="javavspython">
   <head>
     <meta charset="utf-8">
-    <title>One vs Two -- Result</title>
+    <title>Pyhton vs Javascript -- Result</title>
     <base href="/index.html">
     <meta name = "viewport" content = "width=device-width, initial-scale = 1.0">
     <meta name="keywords" content="docker-compose, docker, stack">
@@ -20,12 +20,12 @@
       <div id="content-container-center">
         <div id="choice">
           <div class="choice one">
-            <div class="label">One</div>
+            <div class="label">Python</div>
             <div class="stat">{{aPercent | number:1}}%</div>
           </div>
           <div class="divider"></div>
           <div class="choice two">
-            <div class="label">Two</div>
+            <div class="label">JavaScript</div>
             <div class="stat">{{bPercent | number:1}}%</div>
           </div>
         </div>

--- a/example-voting-app/voting-app/Dockerfile
+++ b/example-voting-app/voting-app/Dockerfile
@@ -11,8 +11,8 @@ RUN pip install -r requirements.txt
 # Copy our code from the current folder to /app inside the container
 ADD . /app
 
-# Make port 80 available for links and/or publish
-EXPOSE 80
+# Make port 5000 available for links and/or publish
+EXPOSE 5000
 
 # Define our command to be run when launching the container
 CMD ["python", "app.py"]

--- a/example-voting-app/voting-app/app.py
+++ b/example-voting-app/voting-app/app.py
@@ -8,8 +8,8 @@ import socket
 import random
 import json
 
-option_a = os.getenv('OPTION_A', "One")
-option_b = os.getenv('OPTION_B', "Two")
+option_a = os.getenv('OPTION_A', "Python")
+option_b = os.getenv('OPTION_B', "Javascript")
 
 hostname = socket.gethostname()
 

--- a/example-voting-app/voting-app/app.py
+++ b/example-voting-app/voting-app/app.py
@@ -43,4 +43,4 @@ def hello():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=80, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
Implement and manage the scale up voting-app event, then we need consider that interlock only work with hostname right now.
So in this example we should use http://test.local

Aslo I change the voting-app listen port, from 80 to 5000
