### PR TITLE
Add HAProxy load balancer, autoscaling functionality and simple load testing

### DIFF
--- a/example-voting-app/autoscale.py
+++ b/example-voting-app/autoscale.py
@@ -1,0 +1,47 @@
+from docker import Client
+from docker.utils import kwargs_from_env
+
+from subprocess import call
+
+
+cli = Client(**kwargs_from_env(assert_hostname=False))
+
+def scale(container, cpu_usage, scale_dict):
+    scale_num = scale_dict[container]
+
+    if (cpu_usage > 30):
+        print("Will scale [%s] to %d instances." % (container, scale_num+1))
+        call(["docker-compose", "scale", "%s=%s" % (container, str(scale_num+1))])
+        return "scaled";
+    elif (cpu_usage < 5 and scale_num > 1):
+        print("Will reduce [%s] to %d instances." % (container, scale_num-1))
+        call(["docker-compose", "scale", "%s=%s" % (container, str(scale_num-1))])
+        return "scaled";
+    return "unscaled";
+
+while True:
+    # ls = [x for x in lst if (("a" in x) or ("b" in x))]
+    # get names of all containers in an array
+    container_list = [str(x["Names"][0]) for x in cli.containers()]
+    # check only for voting-app or worker
+    short_cont_list = [x[1:] for x in container_list if (("voting-app" in x) or ("worker" in x))]
+    # keep the number of instances for each category to define the number to scale
+    scale_dict = {}
+    scale_dict["voting-app"] = len([x for x in short_cont_list if ("voting-app" in x)])
+    scale_dict["worker"] = len([x for x in short_cont_list if ("worker" in x)])
+
+    for container in short_cont_list:
+        # gather cpu stats
+        stats_obj = cli.stats(container, stream=False)
+        cpuDelta = stats_obj['cpu_stats']['cpu_usage']['total_usage'] - stats_obj['precpu_stats']['cpu_usage']['total_usage']
+        systemDelta = float(stats_obj['cpu_stats']['system_cpu_usage']) - float(stats_obj['precpu_stats']['system_cpu_usage'])
+        cpu_usage = (cpuDelta/systemDelta) * float(len(stats_obj['cpu_stats']['cpu_usage']['percpu_usage'])) * 100.0
+        # decide whether to scale
+        scaled = ""
+        if "voting-app" in container:
+            scaled = scale("voting-app", cpu_usage, scale_dict)
+        elif "worker" in container:
+            scaled = scale("worker", cpu_usage, scale_dict)
+        # if scaled break the loop to avoid scaling multiple times
+        if scaled == "scaled":
+            break

--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -1,15 +1,38 @@
 version: "2"
 
 services:
+  lb:
+    image: dockercloud/haproxy
+    depends_on:
+      - voting-app
+    ports:
+      - "80:80"
+      - "1936:1936"
+    links:
+      - voting-app
+    environment:
+      - DOCKER_TLS_VERIFY
+      - DOCKER_HOST
+      - DOCKER_CERT_PATH
+    volumes:
+      - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
+
+  lt:
+    build: ./load-testing/.
+    volumes:
+      - ./load-testing:/app
+    ports:
+      - "8089:8089"
+
   voting-app:
     build: ./voting-app/.
     volumes:
-     - ./voting-app:/app
+      - ./voting-app:/app
     ports:
-      - "5000:80"
-    networks:
-      - front-tier
-      - back-tier
+      - "80"
+    links:
+      - redis
+      - result-app
 
   result-app:
     build: ./result-app/.
@@ -17,33 +40,26 @@ services:
       - ./result-app:/app
     ports:
       - "5001:80"
-    networks:
-      - front-tier
-      - back-tier
+    links:
+      - db
 
   worker:
     image: manomarks/worker
-    networks:
-      - back-tier
+    links:
+      - db
 
   redis:
     image: redis:alpine
     container_name: redis
     ports: ["6379"]
-    networks:
-      - back-tier
+    links:
+      - worker
 
   db:
     image: postgres:9.4
     container_name: db
     volumes:
       - "db-data:/var/lib/postgresql/data"
-    networks:
-      - back-tier
 
 volumes:
   db-data:
-
-networks:
-  front-tier:
-  back-tier:

--- a/example-voting-app/load-testing/Dockerfile
+++ b/example-voting-app/load-testing/Dockerfile
@@ -1,0 +1,18 @@
+# Using official python runtime base image
+FROM python:2
+
+# Set the application directory
+WORKDIR /app
+
+# Install our requirements.txt
+ADD requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy our code from the current folder to /app inside the container
+ADD . /app
+
+# Make port 8089 available for links and/or publish
+EXPOSE 8089
+
+# Define our command to be run when launching the container
+CMD ["locust"]

--- a/example-voting-app/load-testing/locustfile.py
+++ b/example-voting-app/load-testing/locustfile.py
@@ -1,0 +1,15 @@
+from locust import HttpLocust, TaskSet
+
+import random
+
+
+def vote(l):
+    vote = random.choice(['a', 'b'])
+    l.client.post('/', data={"vote": vote})
+
+class UserBehavior(TaskSet):
+    tasks = {vote:1}
+
+class WebsiteUser(HttpLocust):
+    task_set = UserBehavior
+    host = "http://192.168.99.100"

--- a/example-voting-app/load-testing/requirements.txt
+++ b/example-voting-app/load-testing/requirements.txt
@@ -1,0 +1,10 @@
+Flask==0.10.1
+gevent==1.1.1
+greenlet==0.4.9
+itsdangerous==0.24
+Jinja2==2.8
+locustio==0.7.3
+MarkupSafe==0.23
+msgpack-python==0.4.7
+requests==2.9.1
+Werkzeug==0.11.8

--- a/example-voting-app/requirements.txt
+++ b/example-voting-app/requirements.txt
@@ -1,0 +1,5 @@
+docker-py==1.8.0
+py2-ipaddress==3.4.1
+requests==2.9.1
+six==1.10.0
+websocket-client==0.37.0

--- a/example-voting-app/result-app/views/config.json
+++ b/example-voting-app/result-app/views/config.json
@@ -1,7 +1,7 @@
 {
-  "name":"Gordon",
-  "twitter":"@docker",
-  "location":"San Francisco, CA, USA",
-  "repo":["example/votingapp_voting-app","example/votingapp_result-app"],
-  "vote":"Cat"
+  "name":"Konstantinos Faliagkas",
+  "twitter":"@kwst_f",
+  "location":"Manchester, UK",
+  "repo":["ksketo/votingapp_voting-app","ksketo/votingapp_result-app"],
+  "vote":"Python"
 }

--- a/example-voting-app/voting-app/app.py
+++ b/example-voting-app/voting-app/app.py
@@ -8,8 +8,8 @@ import socket
 import random
 import json
 
-option_a = os.getenv('OPTION_A', "One")
-option_b = os.getenv('OPTION_B', "Two")
+option_a = os.getenv('OPTION_A', "Python")
+option_b = os.getenv('OPTION_B', "Javascript")
 
 hostname = socket.gethostname()
 


### PR DESCRIPTION
**Description**

I added three features to the initial app:
1. A haproxy load balancer, based on the dockercloud/haproxy image, for dynamic configuration.
2. Dockerized the locust load testing framework, in order to create fake http requests to the voting page.
3. Autoscaling of the voting-app and worker containers. Using the docker remote api, I monitor the cpu usage of the two containers and scale up or down, depending on the threshold. The bottom threshold is 5% and the upper at 30%. 

**Quick Start**

In order to replicate:
1. Go to the example-voting-app dir
2. Run the application with the docker-compose file. At that point you should be able to access the voting page at '/', the result page at port 5001 and the locust admin page at 8089
3. Run the command `pip install -r requirements.txt` and then `python autoscale.py`
4. On a console view docker stats of the running containers. Initially they should be < 1% . Create 100 fake users with locust and see the containers autoscale. Once you stop the loading or reduce number of users, the containers will automatically downscale. If you create more then 245 requests, many of them will fail. 

**Notes**
- For some reason the dockercloud/haproxy image wasn’t working with the network option configuration (the container would directly exit), so I used links instead. The other option would be to use a discovery service and go templates, in order to dynamically configure load balancing.
- I was getting a limit of 245 maximum number of connections. After that number the http requests would fail. I didn't find a way to change that with the haproxy image I used (it wasn't the MAXCONN env), so considering that limitation, I set the threshold for scaling to 30% cpu usage.
- For the autoscale.py there is a docker anti-patter. No container here. I am using the docker remote api and I didn’t figured out how to use it inside a container
- In the locustfile.py you need to change the host to the corresponging ip if you run it on docker-machine or to the localhost, otherwise you won’t be able to create post requests to the voting page
  voting page is now accessed at localhost (or the ip of your docker-machine). Using a specific port at the host wouldn’t allow scaling the container.
