### PR TITLE
Fixing Result App

### DIFF
--- a/example-voting-app/docker-compose.yml
+++ b/example-voting-app/docker-compose.yml
@@ -13,8 +13,6 @@ services:
 
   result-app:
     build: ./result-app/.
-    volumes:
-      - ./result-app:/app
     ports:
       - "5001:80"
     networks:

--- a/example-voting-app/result-app/Dockerfile
+++ b/example-voting-app/result-app/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /app
 ADD package.json /app/package.json
 RUN npm config set registry http://registry.npmjs.org
 RUN npm install && npm ls
-RUN mv /app/node_modules /node_modules
 
 ADD . /app
 


### PR DESCRIPTION
Something must have changed in a base image or these files along the way, but today if you clone the birthday app and try to start the example voting app with docker-compose the result-app fails to start due to missing express. To fix the issue I had to remove the line from the dockerfile that moved app/node_modules to /node_modules and remove the volume definition from docker-compose.

I was able to duplicate this issue on Ubuntu 15.10 using native Docker, on Docker for Mac, and Docker in VirtualBox on Mac (Docker Toolbox setup). 

Here is the Docker logs output of the results-app failing:

```
$ docker-compose logs result-app
Attaching to examplevotingapp_result-app_1
result-app_1 | module.js:440
result-app_1 |     throw err;
result-app_1 |     ^
result-app_1 | 
result-app_1 | Error: Cannot find module 'express'
result-app_1 |     at Function.Module._resolveFilename (module.js:438:15)
result-app_1 |     at Function.Module._load (module.js:386:25)
result-app_1 |     at Module.require (module.js:466:17)
result-app_1 |     at require (internal/module.js:20:19)
result-app_1 |     at Object.<anonymous> (/app/server.js:1:77)
result-app_1 |     at Module._compile (module.js:541:32)
result-app_1 |     at Object.Module._extensions..js (module.js:550:10)
result-app_1 |     at Module.load (module.js:456:32)
result-app_1 |     at tryModuleLoad (module.js:415:12)
result-app_1 |     at Function.Module._load (module.js:407:3)
```
